### PR TITLE
github: ci: add MIPS64, PowerPC64 and RISCV64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   push:
 
+env:
+  archs: "aarch64 arm mips mips64 powerpc powerpc64 riscv64 x86_64"
+  variants: "build"
+
 jobs:
   build:
     name: Build ${{ matrix.arch }}
@@ -21,9 +25,18 @@ jobs:
           - arch: mips
             gcc: /usr/bin/mips-linux-gnu-gcc
             packages: gcc-mips-linux-gnu
+          - arch: mips64
+            gcc: /usr/bin/mips64-linux-gnuabi64-gcc
+            packages: gcc-mips64-linux-gnuabi64
           - arch: powerpc
             gcc: /usr/bin/powerpc-linux-gnu-gcc
             packages: gcc-powerpc-linux-gnu
+          - arch: powerpc64
+            gcc: /usr/bin/powerpc64-linux-gnu-gcc
+            packages: gcc-powerpc64-linux-gnu
+          - arch: riscv64
+            gcc: /usr/bin/riscv64-linux-gnu-gcc
+            packages: gcc-riscv64-linux-gnu
           - arch: x86_64
             gcc: /usr/bin/x86_64-linux-gnu-gcc
             packages: gcc-x86-64-linux-gnu
@@ -34,8 +47,14 @@ jobs:
       size-arm-so: ${{ steps.build.outputs.size_arm_so }}
       size-mips-a: ${{ steps.build.outputs.size_mips_a }}
       size-mips-so: ${{ steps.build.outputs.size_mips_so }}
+      size-mips64-a: ${{ steps.build.outputs.size_mips64_a }}
+      size-mips64-so: ${{ steps.build.outputs.size_mips64_so }}
       size-powerpc-a: ${{ steps.build.outputs.size_powerpc_a }}
       size-powerpc-so: ${{ steps.build.outputs.size_powerpc_so }}
+      size-powerpc64-a: ${{ steps.build.outputs.size_powerpc64_a }}
+      size-powerpc64-so: ${{ steps.build.outputs.size_powerpc64_so }}
+      size-riscv64-a: ${{ steps.build.outputs.size_riscv64_a }}
+      size-riscv64-so: ${{ steps.build.outputs.size_riscv64_so }}
       size-x86_64-a: ${{ steps.build.outputs.size_x86_64_a }}
       size-x86_64-so: ${{ steps.build.outputs.size_x86_64_so }}
     steps:
@@ -88,13 +107,53 @@ jobs:
           size_arm_so: ${{needs.build.outputs.size-arm-so}}
           size_mips_a: ${{needs.build.outputs.size-mips-a}}
           size_mips_so: ${{needs.build.outputs.size-mips-so}}
+          size_mips64_a: ${{needs.build.outputs.size-mips64-a}}
+          size_mips64_so: ${{needs.build.outputs.size-mips64-so}}
           size_powerpc_a: ${{needs.build.outputs.size-powerpc-a}}
           size_powerpc_so: ${{needs.build.outputs.size-powerpc-so}}
+          size_powerpc64_a: ${{needs.build.outputs.size-powerpc64-a}}
+          size_powerpc64_so: ${{needs.build.outputs.size-powerpc64-so}}
+          size_riscv64_a: ${{needs.build.outputs.size-riscv64-a}}
+          size_riscv64_so: ${{needs.build.outputs.size-riscv64-so}}
           size_x86_64_a: ${{needs.build.outputs.size-x86_64-a}}
           size_x86_64_so: ${{needs.build.outputs.size-x86_64-so}}
         run: |
           echo "### ${GITHUB_WORKFLOW} sizes :floppy_disk:" >> $GITHUB_STEP_SUMMARY
-          echo "| Variant | aarch64 | arm | mips | powerpc | x86_64 |" >> $GITHUB_STEP_SUMMARY
-          echo "| :---: | :---: | :---: | :---: | :---: | :---: |" >> $GITHUB_STEP_SUMMARY
-          echo "| libnl-tiny.a | ${size_aarch64_a} | ${size_arm_a} | ${size_mips_a} | ${size_powerpc_a} | ${size_x86_64_a} |" >> $GITHUB_STEP_SUMMARY
-          echo "| libnl-tiny.so | ${size_aarch64_so} | ${size_arm_so} | ${size_mips_so} | ${size_powerpc_so} | ${size_x86_64_so} |" >> $GITHUB_STEP_SUMMARY
+
+          header="| libnl-tiny.a |"
+          table="| :---: |"
+          for variant in ${{ env.variants }}; do
+            header="$header $variant |"
+            table="$table :---: |"
+          done
+          echo $header >> $GITHUB_STEP_SUMMARY
+          echo $table >> $GITHUB_STEP_SUMMARY
+
+          for arch in ${{ env.archs }}; do
+            row="| $arch | "
+            for variant in $variants; do
+              value=size_${arch}_a
+              row="$row ${!value} |"
+            done
+            echo $row >> $GITHUB_STEP_SUMMARY
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          header="| libnl-tiny.so |"
+          table="| :---: |"
+          for variant in ${{ env.variants }}; do
+            header="$header $variant |"
+            table="$table :---: |"
+          done
+          echo $header >> $GITHUB_STEP_SUMMARY
+          echo $table >> $GITHUB_STEP_SUMMARY
+
+          for arch in ${{ env.archs }}; do
+            row="| $arch | "
+            for variant in $variants; do
+              value=size_${arch}_so
+              row="$row ${!value} |"
+            done
+            echo $row >> $GITHUB_STEP_SUMMARY
+          done


### PR DESCRIPTION
MIPS64, PowerPC64 and RISCV64 are popular OpenWrt archs.
Refactor the sizes build step to generate the table programatically.